### PR TITLE
실시간 인기차트 목록 스타일 변경

### DIFF
--- a/lib/components/horizontal_chart_tile.dart
+++ b/lib/components/horizontal_chart_tile.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:Vibes/model/VideoModel.dart';
+import 'package:Vibes/services/utils.dart';
+
+class HorizontalChartTile extends StatelessWidget {
+  final VideoModel video;
+  final int ranking;
+  final VoidCallback onTap;
+
+  const HorizontalChartTile({
+    required this.video,
+    required this.ranking,
+    required this.onTap,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 160,
+        margin: EdgeInsets.only(right: 12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 썸네일 및 순위 배지
+            SizedBox(
+              height: 90,
+              child: Stack(
+                children: [
+                  // 썸네일
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: SizedBox(
+                      width: double.infinity,
+                      height: double.infinity,
+                      child: video.thumbnailUrls != null && video.thumbnailUrls!.isNotEmpty
+                          ? Image.network(
+                              video.thumbnailUrls!.first,
+                              fit: BoxFit.cover,
+                              errorBuilder: (context, error, stackTrace) {
+                                return Container(
+                                  decoration: BoxDecoration(
+                                    gradient: LinearGradient(
+                                      begin: Alignment.topLeft,
+                                      end: Alignment.bottomRight,
+                                      colors: [
+                                        Colors.grey[300]!,
+                                        Colors.grey[400]!,
+                                      ],
+                                    ),
+                                  ),
+                                  child: Icon(
+                                    Icons.music_note,
+                                    color: Colors.grey[600],
+                                    size: 32,
+                                  ),
+                                );
+                              },
+                            )
+                          : Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topLeft,
+                                  end: Alignment.bottomRight,
+                                  colors: [
+                                    Colors.grey[300]!,
+                                    Colors.grey[400]!,
+                                  ],
+                                ),
+                              ),
+                              child: Icon(
+                                Icons.music_note,
+                                color: Colors.grey[600],
+                                size: 32,
+                              ),
+                            ),
+                    ),
+                  ),
+                  
+                  // 순위 배지 (개선된 디자인)
+                  Positioned(
+                    top: 8,
+                    left: 8,
+                    child: Container(
+                      width: 28,
+                      height: 28,
+                      decoration: BoxDecoration(
+                        gradient: ranking <= 3
+                            ? LinearGradient(
+                                begin: Alignment.topLeft,
+                                end: Alignment.bottomRight,
+                                colors: [
+                                  Theme.of(context).colorScheme.primary,
+                                  Theme.of(context).colorScheme.primary.withValues(alpha: 0.8),
+                                ],
+                              )
+                            : LinearGradient(
+                                begin: Alignment.topLeft,
+                                end: Alignment.bottomRight,
+                                colors: [
+                                  Colors.black.withValues(alpha: 0.8),
+                                  Colors.black.withValues(alpha: 0.6),
+                                ],
+                              ),
+                        borderRadius: BorderRadius.circular(14),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.3),
+                            blurRadius: 4,
+                            offset: Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: Center(
+                        child: Text(
+                          '$ranking',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 12,
+                            shadows: [
+                              Shadow(
+                                color: Colors.black.withValues(alpha: 0.5),
+                                blurRadius: 2,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  
+                  // 재생 시간 (개선된 디자인)
+                  if (video.duration != null)
+                    Positioned(
+                      bottom: 8,
+                      right: 8,
+                      child: Container(
+                        padding: EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.9),
+                          borderRadius: BorderRadius.circular(6),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: 0.2),
+                              blurRadius: 2,
+                              offset: Offset(0, 1),
+                            ),
+                          ],
+                        ),
+                        child: Text(
+                          video.duration!,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 10,
+                            fontWeight: FontWeight.w600,
+                            letterSpacing: 0.5,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            
+            SizedBox(height: 8),
+            
+            // 텍스트 영역 (흰색 배경)
+            Container(
+              width: double.infinity,
+              padding: EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(8),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.08),
+                    blurRadius: 4,
+                    offset: Offset(0, 1),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 제목
+                  Text(
+                    video.title ?? 'Unknown Title',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      height: 1.3,
+                      letterSpacing: -0.2,
+                      color: Colors.black87,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  
+                  SizedBox(height: 4),
+                  
+                  // 조회수
+                  Text(
+                    formatViewCount(video.views),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.black54,
+                      fontWeight: FontWeight.w500,
+                      letterSpacing: 0.2,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screen/HomeScreen.dart
+++ b/lib/screen/HomeScreen.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:Vibes/model/VideoModel.dart';
 import 'package:Vibes/services/YoutubeMusicChartState.dart';
 import 'package:Vibes/services/utils.dart';
-import 'package:Vibes/components/chart_tile.dart';
+import 'package:Vibes/components/horizontal_chart_tile.dart';
 
 // ignore: must_be_immutable
 class HomeScreen extends StatefulWidget {
@@ -101,7 +101,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
                 // 차트 리스트
                 Expanded(
-                  child: _buildChartContent(chartState),
+                  child: SingleChildScrollView(
+                    child: _buildChartContent(chartState),
+                  ),
                 ),
               ],
             ),
@@ -161,7 +163,7 @@ class _HomeScreenState extends State<HomeScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Container(
+            SizedBox(
               width: 200,
               height: 200,
               child: Image.asset(
@@ -186,6 +188,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: [
         // 섹션 타이틀
         Padding(
@@ -209,69 +212,29 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
         ),
 
-        // 차트 리스트
-        Expanded(
-          child: ListView.separated(
-            padding: EdgeInsets.symmetric(vertical: 8),
+        // 차트 리스트 (가로 스크롤)
+        SizedBox(
+          height: 200,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             itemCount: chartState.chartVideos.length,
-            separatorBuilder: (context, index) => Divider(
-              height: 1,
-              thickness: 0.5,
-              indent: 16,
-              endIndent: 16,
-              color: Theme.of(context)
-                  .colorScheme
-                  .secondary
-                  .withValues(alpha: 0.3),
-            ),
             itemBuilder: (context, index) {
               final VideoModel video = chartState.chartVideos[index];
-              return GestureDetector(
+              return HorizontalChartTile(
+                video: video,
+                ranking: index + 1,
                 onTap: () {
                   showDetailVideoFromModel(
                       selectedVideo: video, context: context);
                 },
-                child: Row(
-                  children: [
-                    // 순위 표시
-                    Padding(
-                      padding: EdgeInsets.only(left: 14, right: 2),
-                      child: Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color: index < 3
-                              ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context)
-                                  .colorScheme
-                                  .secondary
-                                  .withValues(alpha: 0.3),
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        child: Center(
-                          child: Text(
-                            '${index + 1}',
-                            style: TextStyle(
-                              color: index < 3
-                                  ? Colors.white
-                                  : Theme.of(context).colorScheme.onSurface,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 12,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    // 차트 타일
-                    Expanded(
-                      child: ChartTile(video: video),
-                    ),
-                  ],
-                ),
               );
             },
           ),
         ),
+        
+        // 추가 공간 (향후 다른 섹션 추가 가능)
+        SizedBox(height: 20),
       ],
     );
   }


### PR DESCRIPTION
🎯 주요 변경사항

  1. 레이아웃 구조 변경

  - 세로 리스트 → 가로 스크롤: 기존 세로 ListView를 넷플릭스 스타일의 가로 스크롤 ListView로 변경
  - 화면 공간 효율성: 세로로 많은 공간을 차지하던 차트를 가로 200px 높이로 압축

  2. 새로운 HorizontalChartTile 컴포넌트 생성

  - 넷플릭스 스타일 카드: 160px 너비의 카드형 디자인
  - 큰 썸네일: 90px 높이의 16:9 비율 썸네일
  - 순위 배지: 좌상단에 그라데이션 배지로 순위 표시

  3. 시각적 개선
  - ✅ 텍스트 배경 추가: 제목과 조회수에 흰색 배경 컨테이너 적용

  4. 가독성 향상

  - 명확한 텍스트: 흰색 배경으로 텍스트 가독성 대폭 개선
  - 일관된 색상: 텍스트 색상을 고정하여 테마 독립적 가독성 확보
  - 깔끔한 디자인: 불필요한 시각적 요소 제거로 단순하고 깔끔한 UI

  📂 수정된 파일

  - lib/components/horizontal_chart_tile.dart (신규 생성)
  - lib/screen/HomeScreen.dart (레이아웃 변경)

  🎨 최종 결과

  세로로 많은 공간을 차지하던 인기차트가 가로 스크롤 형태로 변경되어 화면 공간을 효율적으로
  사용하면서, 넷플릭스와 같은 현대적인 UI/UX를 제공합니다.